### PR TITLE
提交compress、compress/bzip2、compress/flate、compress/lzw包示例

### DIFF
--- a/compress/README.md
+++ b/compress/README.md
@@ -1,4 +1,4 @@
-﻿# Comprss
+﻿# compress
 
 二级包列表
 

--- a/compress/README.md
+++ b/compress/README.md
@@ -1,5 +1,9 @@
-# Comprss
+﻿# Comprss
 
 二级包列表
 
+- [compress/bzip2](bzip2)
+- [compress/flate](flate)
 - [compress/gzip](gzip)
+- [compress/lzw](lzw)
+- [compress/zlib](zlib)

--- a/compress/bzip2/NewReader.md
+++ b/compress/bzip2/NewReader.md
@@ -1,0 +1,56 @@
+﻿# func NewReader(r io.Reader) io.Reader
+
+参数列表：
+
+- r bzip2压缩数据
+
+返回值：解压后的数据
+
+功能说明：
+
+返回一个从r读取bzip2压缩数据，然后返回一个解压后io.Reader
+
+示例：
+
+	package main
+	
+	import (
+		"archive/tar"
+		"compress/bzip2"
+		"fmt"
+		"io"
+		"os"
+		"path"
+	)
+	
+	func main() {
+		//打开一个bz2压缩文件
+		bzip2File, _ := os.Open("demo.tar.bz2")
+		defer bzip2File.Close()
+	
+		//进行解压
+		r := bzip2.NewReader(bzip2File)
+		//使用tar读取输出文件
+		tr := tar.NewReader(r)
+		for {
+			tarHead, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				fmt.Println("the tar file err is ", err)
+				continue
+			}
+			fmt.Println(tarHead.Name)
+	
+			os.MkdirAll(path.Dir(tarHead.Name), os.ModePerm)
+			fw, _ := os.Create(tarHead.Name)
+			defer fw.Close()
+	
+			_, err = io.Copy(fw, tr)
+			if err != nil {
+				fmt.Println("copy file err is ", err)
+				continue
+			}
+		}
+	}

--- a/compress/bzip2/README.md
+++ b/compress/bzip2/README.md
@@ -1,6 +1,6 @@
-# 包名
+﻿# 包名 compress/bzip2
 
 函数列表
 
-- xxx1
-- xxx2
+- [func NewReader(r io.Reader) io.Reader](NewReader.md)
+- [func (s StructuralError) Error() string](StructuralError.Error.md)

--- a/compress/bzip2/StructuralError.Error.md
+++ b/compress/bzip2/StructuralError.Error.md
@@ -1,0 +1,40 @@
+﻿# func (s StructuralError) Error() string
+
+返回值：非法的bzip2数据错误信息
+
+功能说明：StructuralError其实是一个string，他实现了error接口，用于很方便的返回非法的bzip2数据的错误信息
+
+示例：
+
+	package main
+	
+	import (
+		"archive/tar"
+		"compress/bzip2"
+		"fmt"
+		"io"
+		"log"
+		"os"
+		"reflect"
+	)
+	
+	func main() {
+		//打开一个非bzip2压缩文件
+		bzip2File, _ := os.Open("main.go")
+		defer bzip2File.Close()
+	
+		//尝试进行解压
+		r := bzip2.NewReader(bzip2File)
+		//使用tar读取输出文件
+		tr := tar.NewReader(r)
+		for {
+			_, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				fmt.Println("the type is ", reflect.TypeOf(err))
+				log.Fatalln(err)
+			}
+		}
+	}

--- a/compress/flate/CorruptInputError.Error.md
+++ b/compress/flate/CorruptInputError.Error.md
@@ -1,0 +1,9 @@
+﻿# func (e CorruptInputError) Error() string
+
+返回值：在输入的指定偏移量位置存在损坏的错误信息
+
+功能说明：CorruptInputError其实是一个int64，他实现了error接口，用于很方便的返回输入的指定偏移量位置存在损坏的错误信息
+
+示例：
+
+可能是一些读取、写入、拷贝等函数返回的error信息，这里不再举例。

--- a/compress/flate/InternalError.Error.md
+++ b/compress/flate/InternalError.Error.md
@@ -1,0 +1,9 @@
+﻿# func (e InternalError) Error() string
+
+返回值：表示flate数据自身的错误信息
+
+功能说明：InternalError其实是一个string，他实现了error接口，用于很方便的返回flate数据自身的错误信息
+
+示例：
+
+函数返回的error信息，这里不再举例。

--- a/compress/flate/NewReader.md
+++ b/compress/flate/NewReader.md
@@ -1,0 +1,46 @@
+﻿# func NewReader(r io.Reader) io.ReadCloser
+
+参数列表
+
+- r DEFLATE压缩的数据
+
+返回值：解压后的ReadCloser数据 
+
+功能说明：
+
+从r读取DEFLATE压缩数据，返回一个解压过的io.ReadCloser，使用后需要调用者关闭该io.ReadCloser
+
+示例：
+
+	package main
+	
+	import (
+		"bytes"
+		"compress/flate"
+		"fmt"
+		"io"
+		"log"
+		"os"
+	)
+	
+	func main() {
+		//一个缓冲区存储压缩的内容
+		buf := bytes.NewBuffer(nil)
+	
+		//创建一个flate.Writer
+		flateWrite, err := flate.NewWriter(buf, flate.BestCompression)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		defer flateWrite.Close()
+		//写入待压缩内容
+		flateWrite.Write([]byte("compress/flate\n"))
+		flateWrite.Flush()
+		fmt.Println(buf)
+	
+		//解压刚刚压缩的内容
+		flateReader := flate.NewReader(buf)
+		defer flateReader.Close()
+		//输出
+		io.Copy(os.Stdout, flateReader)
+	}

--- a/compress/flate/NewReaderDict.md
+++ b/compress/flate/NewReaderDict.md
@@ -3,7 +3,7 @@
 参数列表
 
 - r DEFLATE压缩的数据
-- dict 解压数据时预设的字典，和NewWriterDict函数里多的dict相同
+- dict 解压数据时预设的字典，和NewWriterDict函数里的dict相同
 
 返回值：解压后的ReadCloser数据 
 

--- a/compress/flate/NewReaderDict.md
+++ b/compress/flate/NewReaderDict.md
@@ -1,0 +1,48 @@
+﻿# func NewReaderDict(r io.Reader, dict []byte) io.ReadCloser
+
+参数列表
+
+- r DEFLATE压缩的数据
+- dict 解压数据时预设的字典，和NewWriterDict函数里多的dict相同
+
+返回值：解压后的ReadCloser数据 
+
+功能说明：
+
+从r读取DEFLATE压缩数据，使用预设的dict字典解压数据，返回一个解压过的io.ReadCloser，使用后需要调用者关闭该io.ReadCloser。主要用来读取NewWriterDict压缩的数据
+
+示例：
+
+	package main
+	
+	import (
+		"bytes"
+		"compress/flate"
+		"fmt"
+		"io"
+		"log"
+		"os"
+	)
+	
+	func main() {
+		//一个缓冲区存储压缩的内容
+		buf := bytes.NewBuffer(nil)
+	
+		//创建一个flate.Writer
+		flateWrite, err := flate.NewWriterDict(buf, flate.BestCompression, []byte("key"))
+		if err != nil {
+			log.Fatalln(err)
+		}
+		defer flateWrite.Close()
+		//写入待压缩内容
+		flateWrite.Write([]byte("compress/flate\n"))
+		flateWrite.Flush()
+		fmt.Println(buf)
+	
+		//解压刚刚压缩的内容
+		flateReader := flate.NewReaderDict(buf, []byte("key"))
+		//flateReader := flate.NewReader(buf)
+		defer flateReader.Close()
+		//输出
+		io.Copy(os.Stdout, flateReader)
+	}

--- a/compress/flate/NewWriter.md
+++ b/compress/flate/NewWriter.md
@@ -1,0 +1,44 @@
+﻿# func NewWriter(w io.Writer, level int) (*Writer, error)
+
+参数列表；
+
+* w 输出数据的Writer
+* level 压缩级别
+
+返回列表：
+
+* *Writer 基于压缩级别新生成的压缩数据的Writer
+* error 该函数的错误信息
+
+功能说明：
+
+该函数返回一个压缩级别为level的新的压缩用的Writer。压缩级别的范围是1 (BestSpeed) to 9 (BestCompression)。压缩效果越好的意味着压缩速度越慢。0 (NoCompression)表示不做任何压缩；仅仅只需要添加必要的DEFLATE信息。-1 (DefaultCompression)表示用默认的压缩级别。
+如果压缩级别在-1到9的范围内，error返回nil，否则将返回非nil的错误信息
+
+示例：
+
+	package main
+	
+	import (
+		"bytes"
+		"compress/flate"
+		"fmt"
+		"log"
+	)
+	
+	func main() {
+		//一个缓冲区存储压缩的内容
+		buf := bytes.NewBuffer(nil)
+	
+		//创建一个flate.Writer，压缩级别最好
+		flateWrite, err := flate.NewWriter(buf, flate.BestCompression)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		defer flateWrite.Close()
+		//写入待压缩内容
+		flateWrite.Write([]byte("compress/flate\n"))
+		flateWrite.Flush()
+		fmt.Println(buf)
+	
+	}

--- a/compress/flate/NewWriterDict.md
+++ b/compress/flate/NewWriterDict.md
@@ -1,0 +1,44 @@
+﻿# func NewWriterDict(w io.Writer, level int, dict []byte) (*Writer, error)
+
+参数列表；
+
+* w 输出数据的Writer
+* level 压缩级别
+* dict 压缩预设字典
+
+返回列表：
+
+* *Writer 基于压缩级别和预设字典新生成的压缩数据的Writer
+* error 该函数的错误信息
+
+功能说明：
+
+该函数和NewWriter差不多，只不过使用了预设字典进行初始化Writer，使用该Writer压缩的数据只能被使用同样字典初始化的Reader解压。可以实现基于密码的解压缩。
+
+示例：
+
+	package main
+	
+	import (
+		"bytes"
+		"compress/flate"
+		"fmt"
+		"log"
+	)
+	
+	func main() {
+		//一个缓冲区存储压缩的内容
+		buf := bytes.NewBuffer(nil)
+	
+		//创建一个flate.Writer，压缩级别最好
+		flateWrite, err := flate.NewWriterDict(buf, flate.BestCompression,[]byte("key"))
+		if err != nil {
+			log.Fatalln(err)
+		}
+		defer flateWrite.Close()
+		//写入待压缩内容
+		flateWrite.Write([]byte("compress/flate\n"))
+		flateWrite.Flush()
+		fmt.Println(buf)
+	
+	}

--- a/compress/flate/README.md
+++ b/compress/flate/README.md
@@ -1,6 +1,26 @@
-# 包名
+﻿# 包名 compress/flate
+
+常量列表
+
+    const (
+        NoCompression = 0//不雅所
+        BestSpeed     = 1//最快速度压缩
+    
+        BestCompression    = 9//最佳压缩比压缩
+        DefaultCompression = -1//默认压缩
+    )
 
 函数列表
 
-- xxx1
-- xxx2
+- [func NewReader(r io.Reader) io.ReadCloser](NewReader.mds)
+- [func NewReaderDict(r io.Reader, dict []byte) io.ReadCloser](NewReaderDict.md)
+- [func (e CorruptInputError) Error() string](CorruptInputError.Error.md)
+- [func (e InternalError) Error() string](InternalError.Error.md)
+- [func (e *ReadError) Error() string](ReadError.Error.md)
+- [func (e *WriteError) Error() string](WriteError.Error.md)
+- [func NewWriter(w io.Writer, level int) (*Writer, error)](NewWriter.md)
+- [func NewWriterDict(w io.Writer, level int, dict []byte) (*Writer, error)](NewWriterDict.md)
+- [func (w *Writer) Close() error](Writer.Close.md)
+- [func (w *Writer) Flush() error](Writer.Flush.md)
+- [func (w *Writer) Reset(dst io.Writer)](Writer.Reset.md)
+- [func (w *Writer) Write(data []byte) (n int, err error)](Writer.Write.md)

--- a/compress/flate/README.md
+++ b/compress/flate/README.md
@@ -3,7 +3,7 @@
 常量列表
 
     const (
-        NoCompression = 0//不雅所
+        NoCompression = 0//不压缩
         BestSpeed     = 1//最快速度压缩
     
         BestCompression    = 9//最佳压缩比压缩
@@ -12,7 +12,7 @@
 
 函数列表
 
-- [func NewReader(r io.Reader) io.ReadCloser](NewReader.mds)
+- [func NewReader(r io.Reader) io.ReadCloser](NewReader.md)
 - [func NewReaderDict(r io.Reader, dict []byte) io.ReadCloser](NewReaderDict.md)
 - [func (e CorruptInputError) Error() string](CorruptInputError.Error.md)
 - [func (e InternalError) Error() string](InternalError.Error.md)

--- a/compress/flate/ReadError.Error.md
+++ b/compress/flate/ReadError.Error.md
@@ -1,0 +1,9 @@
+﻿# func (e *ReadError) Error() string
+
+返回值：表示flate读取拷贝数据时的错误信息
+
+功能说明：ReadError其实是一个struct，他实现了error接口，用于很方便的返回flate读取拷贝数据时的错误信息
+
+示例：
+
+flate读取拷贝数据时的错误信息，这里不再举例。

--- a/compress/flate/WriteError.Error.md
+++ b/compress/flate/WriteError.Error.md
@@ -1,0 +1,9 @@
+﻿# func (e *WriteError) Error() string
+
+返回值：表示flate输出数据的错误信息
+
+功能说明：WriteError是一个struct，他实现了error接口，用于很方便的返回flate输出数据的错误信息
+
+示例：
+
+返回输出数据的错误信息，这里不再举例。

--- a/compress/flate/Writer.Close.md
+++ b/compress/flate/Writer.Close.md
@@ -1,0 +1,36 @@
+﻿# func (w *Writer) Close() error
+
+返回值：返回一个error，没有错误时该error为nil
+
+功能说明：
+
+刷新缓冲并关闭w
+
+示例：
+
+	package main
+	
+	import (
+		"bytes"
+		"compress/flate"
+		"fmt"
+		"log"
+	)
+	
+	func main() {
+		//一个缓冲区存储压缩的内容
+		buf := bytes.NewBuffer(nil)
+	
+		//创建一个flate.Writer
+		flateWrite, err := flate.NewWriterDict(buf, flate.BestCompression, []byte("key"))
+		if err != nil {
+			log.Fatalln(err)
+		}
+		//刷新缓存并关闭flateWrite
+		defer flateWrite.Close()
+		//写入待压缩内容
+		flateWrite.Write([]byte("compress/flate\n"))
+		flateWrite.Flush()
+		fmt.Println(buf)
+	
+	}

--- a/compress/flate/Writer.Flush.md
+++ b/compress/flate/Writer.Flush.md
@@ -1,0 +1,38 @@
+﻿# func (w *Writer) Flush() error
+
+返回值：返回一个error，没有错误时该error为nil
+
+功能说明：
+
+Flush将缓存中的压缩数据刷新到下层的io.writer中。它主要用在压缩的网络协议中，目的是确保远程读取器有足够的数据重建一个数据包。Flush是阻塞的，直到缓冲中的数据都被写入到下层io.writer中才返回。如果下层io.writer返回一个error，那么Flush也会返回该error。
+
+在zlib库的术语中，Flush等同于Z_SYNC_FLUSH。
+
+示例：
+
+	package main
+	
+	import (
+		"bytes"
+		"compress/flate"
+		"fmt"
+		"log"
+	)
+	
+	func main() {
+		//一个缓冲区存储压缩的内容
+		buf := bytes.NewBuffer(nil)
+	
+		//创建一个flate.Writer
+		flateWrite, err := flate.NewWriterDict(buf, flate.BestCompression, []byte("key"))
+		if err != nil {
+			log.Fatalln(err)
+		}
+		//刷新缓存并关闭flateWrite
+		defer flateWrite.Close()
+		//写入待压缩内容
+		flateWrite.Write([]byte("compress/flate\n"))
+		flateWrite.Flush()
+		fmt.Println(buf)
+	
+	}

--- a/compress/flate/Writer.Reset.md
+++ b/compress/flate/Writer.Reset.md
@@ -1,0 +1,42 @@
+﻿# func (w *Writer) Reset(dst io.Writer)
+
+参数列表：
+
+- dst 重置时将为作w的下层io.Writer
+
+功能说明：
+
+Reset会丢弃当前的w的状态，这相当于把dst、w的级别和字典作为参数，重新调用NewWriter或者NewWriterDict函数一样。
+
+示例：
+
+	package main
+	
+	import (
+		"bytes"
+		"compress/flate"
+		"fmt"
+		"log"
+	)
+	
+	func main() {
+		//一个缓冲区存储压缩的内容
+		buf := bytes.NewBuffer(nil)
+	
+		//创建一个flate.Writer
+		flateWrite, err := flate.NewWriterDict(buf, flate.BestCompression, []byte("key"))
+		if err != nil {
+			log.Fatalln(err)
+		}
+		defer flateWrite.Close()
+	
+		//reset
+		buf1 := bytes.NewBuffer(nil)
+		flateWrite.Reset(buf1)
+		//写入待压缩内容
+		flateWrite.Write([]byte("compress/flate\n"))
+		flateWrite.Flush()
+		fmt.Println(buf)  //什么都没有一个空行，因为我们reset重置了
+		fmt.Println(buf1) //这个会输出结果，因为下层io.Writer被替换为buf1了
+	}
+

--- a/compress/flate/Writer.Write.md
+++ b/compress/flate/Writer.Write.md
@@ -1,0 +1,42 @@
+﻿# func (w *Writer) Write(data []byte) (n int, err error)
+
+参数列表：
+
+- data 要写入的字节数据
+
+返回值：
+
+- n 写入的字节数
+- err 错误信息，无错误返回nil
+
+功能说明：
+
+Write向w写入数据，最终会将压缩格式的数据写入到w的下层io.Writer中
+
+示例：
+
+	package main
+	
+	import (
+		"bytes"
+		"compress/flate"
+		"fmt"
+		"log"
+	)
+	
+	func main() {
+		//一个缓冲区存储压缩的内容
+		buf := bytes.NewBuffer(nil)
+	
+		//创建一个flate.Writer
+		flateWrite, err := flate.NewWriterDict(buf, flate.BestCompression, []byte("key"))
+		if err != nil {
+			log.Fatalln(err)
+		}
+		defer flateWrite.Close()
+	
+		//写入待压缩内容
+		n, _ := flateWrite.Write([]byte("compress/flate\n"))
+		flateWrite.Flush()
+		fmt.Println(n) //15
+	}

--- a/compress/lzw/NewReader.md
+++ b/compress/lzw/NewReader.md
@@ -1,0 +1,42 @@
+﻿# func NewReader(r io.Reader, order Order, litWidth int) io.ReadCloser
+
+参数列表：
+
+- r 待解压的数据
+- order lzw数据流的位顺序，有LSB和MSB
+- litWidth 字面码的位数，必须在[2,8]范围内，一般为8
+
+返回值：一个解压过的io.ReadCloser，调用者使用后要将其关闭
+
+功能说明:
+
+NewReader创建一个新的io.ReadCloser。它从r读取并解压数据。调用者要在读取完之后调用返回io.ReadCloser的Close函数关闭。litWidth是字面码的为数，必须在[2,8]范围内，一般为8.
+
+示例：
+
+	package main
+	
+	import (
+		"bytes"
+		"compress/lzw"
+		"fmt"
+		"io"
+		"os"
+	)
+	
+	func main() {
+		//一个缓冲区存储压缩的内容
+		buf := bytes.NewBuffer(nil)
+	
+		w := lzw.NewWriter(buf, lzw.LSB, 8)
+		//写入待压缩内容
+		w.Write([]byte("compress/flate\n"))
+		w.Close()
+		fmt.Println(buf)
+	
+		//解压
+		r := lzw.NewReader(buf, lzw.LSB, 8)
+		defer r.Close()
+		io.Copy(os.Stdout, r)
+	}
+

--- a/compress/lzw/NewWriter.md
+++ b/compress/lzw/NewWriter.md
@@ -1,0 +1,41 @@
+﻿# func NewWriter(w io.Writer, order Order, litWidth int) io.WriteCloser
+
+参数列表：
+
+- w 输出压缩数据的io.Writer  
+- order lzw数据流的位顺序，有LSB和MSB
+- litWidth 字面码的位数，必须在[2,8]范围内，一般为8
+
+返回值：一个io.WriteCloser，可以将压缩的数据写入其下层的w，调用者使用后要将其关闭
+
+功能说明:
+
+NewWriter创建一个新的io.WriteCloser。它将数据压缩后写入w。调用者要在写入结束之后调用返回io.WriteCloser的Close函数关闭。litWidth是字面码的为数，必须在[2,8]范围内，一般为8.
+
+示例：
+
+	package main
+	
+	import (
+		"bytes"
+		"compress/lzw"
+		"fmt"
+		"io"
+		"os"
+	)
+	
+	func main() {
+		//一个缓冲区存储压缩的内容
+		buf := bytes.NewBuffer(nil)
+	
+		w := lzw.NewWriter(buf, lzw.LSB, 8)
+		//写入待压缩内容
+		w.Write([]byte("compress/flate\n"))
+		w.Close()
+		fmt.Println(buf)
+	
+		//解压
+		r := lzw.NewReader(buf, lzw.LSB, 8)
+		defer r.Close()
+		io.Copy(os.Stdout, r)
+	}

--- a/compress/lzw/README.md
+++ b/compress/lzw/README.md
@@ -1,6 +1,6 @@
-# 包名
+﻿# 包名 compress/lzw
 
 函数列表
 
-- xxx1
-- xxx2
+- [func NewReader(r io.Reader, order Order, litWidth int) io.ReadCloser](NewReader.md)
+- [func NewWriter(w io.Writer, order Order, litWidth int) io.WriteCloser](NewWriter.md)

--- a/todo.md
+++ b/todo.md
@@ -7,11 +7,11 @@
     bufio             : stevewang		-
     builtin           : achun			2013-03-26	finished
     bytes             : stevewang		-
-    compress          : rujews		    2015-01-31
-        - bzip2       : rujews			2015-01-31
-        - flate       : rujews			2015-01-31
+    compress          : rujews		    2015-01-31   finished
+        - bzip2       : rujews			2015-01-31   finished
+        - flate       : rujews			2015-01-31   finished
         - gzip        : Unknown			2013-03-11
-        - lzw         : rujews			2015-01-31
+        - lzw         : rujews			2015-01-31   finished
         - zlib        : lingdecong		2014-11-27
     container         : weager			2013-03-10
         - heap        : weager			2013-03-10


### PR DESCRIPTION
完成了compress、compress/bzip2、compress/flate、compress/lzw四个包的函数示例，其中非函数，比如常量、实现了error接口的错误类型也进行了说明，但是没有示例。