### PR TITLE
Update builtin pkg with go1.21.0

### DIFF
--- a/builtin/any.md
+++ b/builtin/any.md
@@ -1,0 +1,5 @@
+## type any = interface{}
+
+功能说明：
+
+any是interface{}的别名，二者在所有方面都相等。

--- a/builtin/clear.md
+++ b/builtin/clear.md
@@ -1,0 +1,77 @@
+## func clear[T ~[]Type | ~map[Type][Type](t T)
+
+参数说明：
+
+* t T类型元素
+* T Type类型切片或key为Type,value为Type的map
+
+返回值：
+
+* 无
+
+功能说明：
+
+clear 内置函数将清除slice和map中的值。对于map，会删除所有key-value，使map为空。对于slice，会将所有元素设置为改类型的零值。
+
+clear 内置函数参数仅支持slice和map。
+
+代码实例：
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	m1 := map[any]any{
+		1: 1,
+		2: 2,
+		3: 3,
+	}
+	fmt.Printf("%#v\n", m1)
+	clear(m1)
+	fmt.Printf("%#v\n", m1)
+
+	m2 := map[int]string{
+		1: "a",
+		2: "b",
+		3: "c",
+	}
+	fmt.Printf("%#v\n", m2)
+	clear(m2)
+	fmt.Printf("%#v\n", m2)
+	println()
+
+	s1 := []any{
+		'a',
+		'b',
+		'c',
+	}
+	fmt.Printf("%#v\n", s1)
+	clear(s1)
+	fmt.Printf("%#v\n", s1)
+
+	s2 := []string{
+		"a",
+		"b",
+		"c",
+	}
+	fmt.Printf("%#v\n", s2)
+	clear(s2)
+	fmt.Printf("%#v\n", s2)
+}
+```
+
+输出：
+
+```
+map[interface {}]interface {}{1:1, 2:2, 3:3}
+map[interface {}]interface {}{}
+map[int]string{1:"a", 2:"b", 3:"c"}
+map[int]string{}
+
+[]interface {}{97, 98, 99}
+[]interface {}{interface {}(nil), interface {}(nil), interface {}(nil)}
+[]string{"a", "b", "c"}
+[]string{"", "", ""}
+```

--- a/builtin/comparable.md
+++ b/builtin/comparable.md
@@ -1,0 +1,5 @@
+## type comparable interface{ comparable }
+
+功能说明：
+
+comparable 是所有可比较类型实现的接口。只能用作类型参数约束，不能作为变量的类型。

--- a/builtin/iota.md
+++ b/builtin/iota.md
@@ -1,0 +1,42 @@
+## const iota = 0
+
+iota是一个特殊的内置标识符，用于简化常量定义，特别是需要序列递增时。
+
+功能说明：
+
+* iota作为一个常量值，在const块中每次新的常量声明时都会自动递增
+* iota从块中的第一个常量0值开始，后续每个常量依次怎加1
+
+代码实例：
+
+```go
+package main
+
+import "fmt"
+
+const (
+	c0 = iota //iota=0
+	c1        //iota=1
+	c2        //iota=2
+	c3        //iota=3
+)
+const (
+	s0 = iota
+	s1
+	_ //舍弃iota值
+	s3
+)
+
+func main() {
+	fmt.Printf("c0:%d c1:%d c2:%d c3:%d\n", c0, c1, c2, c3)
+	fmt.Printf("s0:%d s1:%d s2:舍弃 s3:%d", s0, s1, s3)
+}
+
+```
+
+输出：
+
+```
+c0:0 c1:1 c2:2 c3:3
+s0:0 s1:1 s2:舍弃 s3:3
+```

--- a/builtin/max.md
+++ b/builtin/max.md
@@ -1,0 +1,41 @@
+## func max[T cmp.Ordered](x T, y ...T) T
+
+参数列表：
+
+* x T类型元素
+* y T类型元素
+* T com.Ordered类型，给类型可以是：~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr | ~float32 | ~float64 | ~string
+
+返回值：
+
+* T类型元素
+
+功能说明：
+
+max 内置函数将返回参数列表中的最大值。当T是浮点类型，并且包含Nan，max()都将返回Nan。
+
+max 参数列表至少要有一个参数。
+
+代码实例：
+
+```go
+package main
+
+func main() {
+	println("max(0,1):", max(0, 1))
+	println("max(0,-1):", max(0, -1))
+	println("max(0,-1.1):", max(0, -1.1))
+	println("max(0,1.1111):", max(0, 1.1111))
+	println("max('a','c'):", string(max('a', 'c')))
+}
+```
+
+输出：
+
+```
+max(0,1): 1
+max(0,-1): 0
+max(0,-1.1): +0.000000e+000
+max(0,1.1111): +1.111100e+000
+max('a','c'): c
+```

--- a/builtin/min.md
+++ b/builtin/min.md
@@ -1,0 +1,41 @@
+## func min[T cmp.Ordered](x T, y ...T) T
+
+参数列表：
+
+* x T类型元素
+* y T类型元素
+* T com.Ordered类型，给类型可以是：~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr | ~float32 | ~float64 | ~string
+
+返回值：
+
+* T类型元素
+
+功能说明：
+
+min 内置函数将返回参数列表中的最小值。当T是浮点类型，并且包含Nan，max()都将返回Nan。
+
+min 参数列表至少要有一个参数。
+
+代码实例：
+
+```go
+package main
+
+func main() {
+	println("min(0,1):", min(0, 1))
+	println("min(0,-1):", min(0, -1))
+	println("min(0,-1.1):", min(0, -1.1))
+	println("min(0,1.1111):", min(0, 1.1111))
+	println("min('a','c'):", string(min('a', 'c')))
+}
+```
+
+输出：
+
+```
+min(0,1): 0
+min(0,-1): -1
+min(0,-1.1): -1.100000e+000
+min(0,1.1111): +0.000000e+000
+min('a','c'): a
+```

--- a/builtin/nil.md
+++ b/builtin/nil.md
@@ -1,0 +1,5 @@
+## var nil Type
+
+功能说明：
+
+nil 是预定义用来表示pointer，channel，func，interface，map和slice类型的零值

--- a/builtin/print.md
+++ b/builtin/print.md
@@ -1,0 +1,65 @@
+## func print(args ...Type)
+
+参数说明：
+
+* args Type类型元素
+* ... 更多的Type类型元素
+
+返回值：
+
+* 无
+
+功能说明：
+
+print 内置函数将通过指定格式来格式化输入参数，并将结果输出到标准错误输出。可在代码调试中使用。
+
+```
+print("hello Go")
+```
+
+代码实例
+
+```go
+package main
+
+func main(){
+	print("hello Go")
+	print("hello ")
+	print("Go")
+}
+```
+
+输出：
+
+```
+hello Gohello Go
+```
+
+##### 注意：print()与println()的区别
+
+二者同样是输出格式化的参数内容到标准错误输出，println()与print()的区别是参数之间添加空格，末尾会添加换行符(\\n)。
+
+代码实例：
+
+```go
+package main
+
+func main() {
+	print("hello Go ")
+	print("hello ")
+	print("Go ")
+	println()
+	println("hello Go")
+	println("hello ")
+	println("Go")
+}
+```
+
+输出：
+
+```
+hello Go hello Go 
+hello Go
+hello
+Go
+```

--- a/builtin/println.md
+++ b/builtin/println.md
@@ -1,0 +1,63 @@
+## func println(args ...Type)
+
+参数列表：
+
+* args Type类型元素
+* ... 更多的Type类型元素
+
+返回值：
+
+* 无
+
+功能说明：
+
+println 内置函数将通过指定格式来格式化输入参数，并将结果输出到标准错误输出。println 函数会在输入参数之间添加空格，末尾添加换行符(\\n)。可在代码调试中使用。
+
+代码实例：
+
+```go
+package main
+
+func main(){
+	println("hello Go")
+	println("hello ")
+	println("Go")
+}
+```
+
+输出：
+
+```
+hello Go
+hello 
+Go
+```
+
+##### 注意：print()与println()的区别
+
+二者同样是输出格式化的参数内容到标准错误输出，println()与print()的区别是参数之间添加空格，末尾会添加换行符(\\n)。
+
+代码实例：
+
+```go
+package main
+
+func main() {
+	print("hello Go ")
+	print("hello ")
+	print("Go ")
+	println()
+	println("hello Go")
+	println("hello ")
+	println("Go")
+}
+```
+
+输出：
+
+```
+hello Go hello Go 
+hello Go
+hello
+Go
+```


### PR DESCRIPTION
Based on go1.21.0 version, new examples of any, comparable, iota, nil, clear(), min(), max(), print(), println(), etc.